### PR TITLE
feat: use neotest-golang

### DIFF
--- a/lua/pde/go.lua
+++ b/lua/pde/go.lua
@@ -115,11 +115,16 @@ return {
   {
     "nvim-neotest/neotest",
     dependencies = {
-      "nvim-neotest/neotest-go",
+      {
+        "fredrikaverpil/neotest-golang",
+        dependencies = {
+          "leoluz/nvim-dap-go",
+        },
+      },
     },
     opts = function(_, opts)
       vim.list_extend(opts.adapters, {
-        require "neotest-go",
+        require "neotest-golang",
       })
     end,
   },

--- a/lua/pde/go.lua
+++ b/lua/pde/go.lua
@@ -89,7 +89,7 @@ return {
               map("n", "<leader>lc", "<cmd>GoCoverage<Cr>", "Go Test Coverage")
               map("n", "<leader>lt", "<cmd>GoTest<Cr>", "Go Test")
               map("n", "<leader>lR", "<cmd>GoRun<Cr>", "Go Run")
-              map("n", "<leader>dT", "<cmd>lua require('dap-go').debug_test()<cr>", "Go Debug Test")
+              map("n", "<leader>dT", "<cmd>lua require('neotest').run.run({ suite = false, strategy = 'dap' })<cr>", "Debug nearest test")
               
               if not client.server_capabilities.semanticTokensProvider then
                 local semantic = client.config.capabilities.textDocument.semanticTokens


### PR DESCRIPTION
Hey 👋 I have come across your Medium blog many times during my journey to set up my Neovim PDE, so I figured I'd reach back out to you 😄 as I've been doing some work to improve the experience when testing and debugging Go tests in Neovim/Neotest. I think maybe you'll like it: [fredrikaverpil/neotest-golang](https://github.com/fredrikaverpil/neotest-golang) 😊

In short, it fixes a bunch of issues from the original neotest-go adapter and making things a lot more robust and speedy. You can read more about it in the repo README!

I've got a few features and improvements lined up next that I want to tackle to make this the best Neotest experience possible for Go devs.

I would love to hear about your thoughts and input on it, if you have any!

Please note that the `<leader>dT` keymap I changed is general to Neotest/DAP and not only meant for Go. It's possible you want to keep the old one too, so have a closer look at that.